### PR TITLE
Force KotlinX Serialization

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Coroutines.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.dependency.kotlinx
+
+/**
+ * Kotlin Coroutines.
+ * 
+ * @see <a href="https://github.com/Kotlin/kotlinx.coroutines">GitHub projecet</a>
+ */
+@Suppress("unused", "ConstPropertyName")
+object Coroutines {
+    const val group = KotlinX.group
+    const val version = "1.10.2"
+    private const val infix = "kotlinx-coroutines"
+    const val bom = "$group:$infix-bom:$version"
+    const val core = "$group:$infix-core:$version"
+    const val coreJvm = "$group:$infix-core-jvm:$version"
+    const val jdk8 = "$group:$infix-jdk8:$version"
+    const val debug = "$group:$infix-debug:$version"
+    const val test = "$group:$infix-test:$version"
+    const val testJvm = "$group:$infix-test-jvm:$version"
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/KotlinX.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.dependency.kotlinx
+
+@Suppress("ConstPropertyName") // https://bit.ly/kotlin-prop-names
+object KotlinX {
+    const val group = "org.jetbrains.kotlinx"
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Serialization.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Serialization.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.dependency.kotlinx
+
+/**
+ * The [KotlinX Serialization](https://github.com/Kotlin/kotlinx.serialization) library.
+ */
+@Suppress("ConstPropertyName") // https://bit.ly/kotlin-prop-names
+object Serialization {
+
+    const val group = KotlinX.group
+
+    /**
+     * The version of the library.
+     *
+     * @see <a href="https://github.com/Kotlin/kotlinx.serialization/releases">Releases</a>
+     */
+    const val version = "1.8.1"
+
+    private const val infix = "kotlinx-serialization"
+    const val bom = "$group:$infix-bom:$version"
+    const val coreJvm = "$group:$infix-core-jvm"
+    const val json = "$group:$infix-json"
+
+    /**
+     * The [Gradle plugin](https://github.com/Kotlin/kotlinx.serialization/tree/master?tab=readme-ov-file#gradle)
+     * for using the serialization library.
+     *
+     * Usage:
+     * ```kotlin
+     * plugins {
+     *     // ...
+     *     kotlin(Serialization.GradlePlugin.shortId) version Kotlin.version
+     * }
+     * ```
+     */
+    object GradlePlugin {
+
+        /**
+         * The ID to be used with the `kotlin(shortId)` DSL under the`plugins { }` block.
+         */
+        const val shortId = "plugin.serialization"
+
+        /**
+         * The full ID of the plugin.
+         */
+        const val id = "org.jetbrains.kotlin.$shortId"
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Coroutines.kt
@@ -28,10 +28,17 @@ package io.spine.dependency.lib
 
 /**
  * Kotlin Coroutines.
- * 
+ *
  * @see <a href="https://github.com/Kotlin/kotlinx.coroutines">GitHub projecet</a>
  */
 @Suppress("unused", "ConstPropertyName")
+@Deprecated(
+    message = "Please use `Coroutines` from `io.spine.dependency.kotlinx` package",
+    replaceWith = ReplaceWith(
+        expression = "Coroutines",
+        imports = ["io.spine.dependency.kotlinx.Coroutines"]
+    )
+)
 object Coroutines {
     const val group = "org.jetbrains.kotlinx"
     const val version = "1.10.2"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
@@ -27,13 +27,23 @@
 package io.spine.dependency.lib
 
 @Suppress("unused", "ConstPropertyName")
+@Deprecated(
+    message = "Please use `KotlinX` from `io.spine.dependency.kotlinx` package",
+    replaceWith = ReplaceWith(
+        expression = "KotlinX",
+        imports = ["io.spine.dependency.kotlinx.KotlinX"]
+    )
+)
 object KotlinX {
 
     const val group = "org.jetbrains.kotlinx"
 
     @Deprecated(
-        message = "Pleaser use top level object `Coroutines` instead.",
-        ReplaceWith("Coroutines")
+        message = "Please use `Coroutines` from `io.spine.dependency.kotlinx` package",
+        replaceWith = ReplaceWith(
+            expression = "Coroutines",
+            imports = ["io.spine.dependency.kotlinx.Coroutines"]
+        )
     )
     object Coroutines {
 

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -28,6 +28,7 @@ import BuildSettings.javaVersion
 import io.spine.dependency.build.CheckerFramework
 import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.JSpecify
+import io.spine.dependency.kotlinx.Serialization
 import io.spine.dependency.lib.Guava
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Logging
@@ -133,7 +134,10 @@ fun Module.forceConfigurations() {
         excludeProtobufLite()
         all {
             resolutionStrategy {
-                force(Logging.lib)
+                force(
+                    Logging.lib,
+                    Serialization.bom
+                )
             }
         }
     }

--- a/dependencies.md
+++ b/dependencies.md
@@ -921,4 +921,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 22 14:45:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 22 14:52:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.201`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.202`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -921,4 +921,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 22 13:28:40 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 22 14:45:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>testlib</artifactId>
-<version>2.0.0-SNAPSHOT.201</version>
+<version>2.0.0-SNAPSHOT.202</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.201")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.202")


### PR DESCRIPTION
This PR introduces the `kotlinx` package for dependency object and uses it for forcing the version of the KotlinX Serialization library.
